### PR TITLE
Fix empy checkout bug

### DIFF
--- a/js/cheddrme.js
+++ b/js/cheddrme.js
@@ -418,6 +418,7 @@ updateTotals = function () {
         finalTotalFiat += parseFloat(orderPriceText);
     });
     $("#orderTotalFiat").text(fiatSymbol + finalTotalFiat.toFixed(2));
+    finalTotal = finalTotalFiat;
 
     finalTotalBCH = finalTotalBits / 1000000;
     $("#orderTotalBCH").text('(₿' + finalTotalBCH.toFixed(8) + ')');


### PR DESCRIPTION
Recreate bug:
- Add item to item list
- Remove all items from item list
- Click Checkout
  -> A payment request is still generated.

Expected behaviour:
-> Error: no items in checkout

This pull request should fix that bug.